### PR TITLE
forge install: chainlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 	branch = v1.5.3
+[submodule "lib/chainlink"]
+	path = lib/chainlink
+	url = https://github.com/smartcontractkit/chainlink


### PR DESCRIPTION
If we want to support a CL-compatible interface we need the interface. I guess we extend our callbacks to accommodate `rawFulfillRandomWords(uint256 requestId, uint256[] memory randomWords)` and its expectations.

All code over there is MIT so we are good to go.

https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol is the relevant interface